### PR TITLE
When nav is parents on /collections count parents

### DIFF
--- a/spec/requests/collections_spec.rb
+++ b/spec/requests/collections_spec.rb
@@ -296,7 +296,7 @@ RSpec.describe '/collections', type: :request do
       '@id' => 'default',
       '@type' => 'Collection',
       'title' => 'Root',
-      'totalItems' => 2,
+      'totalItems' => 0,
     )
   end
 
@@ -314,7 +314,7 @@ RSpec.describe '/collections', type: :request do
       '@id' => 'herodotus',
       '@type' => 'Collection',
       'member' => [
-        { '@id' => 'books', '@type' => 'Collection', 'title' => 'collection of books', 'totalItems' => 2 },
+        { '@id' => 'books', '@type' => 'Collection', 'title' => 'collection of books', 'totalItems' => 1 },
       ],
       'title' => 'histories',
       'totalItems' => 1,
@@ -335,10 +335,10 @@ RSpec.describe '/collections', type: :request do
       '@id' => 'books',
       '@type' => 'Collection',
       'member' => [
-        { '@id' => 'default', '@type' => 'Collection', 'title' => 'Root', 'totalItems' => 2 },
+        { '@id' => 'default', '@type' => 'Collection', 'title' => 'Root', 'totalItems' => 0 },
       ],
       'title' => 'collection of books',
-      'totalItems' => 2,
+      'totalItems' => 1,
     )
   end
 

--- a/spec/requests/partial_collections_spec.rb
+++ b/spec/requests/partial_collections_spec.rb
@@ -107,10 +107,10 @@ RSpec.describe '/collections?page=', type: :request do
       '@id' => 'books',
       '@type' => 'Collection',
       'member' => [
-        { '@id' => 'default', '@type' => 'Collection', 'title' => 'Root', 'totalItems' => 1 },
+        { '@id' => 'default', '@type' => 'Collection', 'title' => 'Root', 'totalItems' => 0 },
       ],
       'title' => 'collection of books',
-      'totalItems' => 25,
+      'totalItems' => 1,
       'view' => {
         '@id' => '/collections?id=books&nav=parents&page=1',
         '@type' => 'PartialCollectionView',


### PR DESCRIPTION
When `nav=parents` on the `/collections` endpoint, count the number of parents instead of the number of children for `totalItems`.